### PR TITLE
Coloring for extra keywords 'self', 'this' and 'super'

### DIFF
--- a/1337.tmTheme
+++ b/1337.tmTheme
@@ -472,11 +472,11 @@
 			<key>name</key>
 			<string>Language Literal</string>
 			<key>scope</key>
-			<string>literal-language-variable</string>
+			<string>variable.language.super, variable.language.this, variable.language.self</string>
 			<key>settings</key>
 			<dict>
 				<key>foreground</key>
-				<string>#29a329</string>
+				<string>#d699ff</string>
 			</dict>
 		</dict>
 	</array>

--- a/1337.tmTheme
+++ b/1337.tmTheme
@@ -468,6 +468,17 @@
 				<string>#66a9ec</string>
 			</dict>
 		</dict>
+		<dict>
+			<key>name</key>
+			<string>Language Literal</string>
+			<key>scope</key>
+			<string>literal-language-variable</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#29a329</string>
+			</dict>
+		</dict>
 	</array>
 	<key>uuid</key>
 	<string>233F0694-0B9C-43E3-A44A-ECECF7DF6C73</string>


### PR DESCRIPTION
I think having an extra color for these keywords is quite useful, especially when programming in javascript. Feel free to change the faded purple color to something else that you think fits the scheme better. Cheers
